### PR TITLE
Fixed error which leads to all new ensembl annotations not being able…

### DIFF
--- a/bin/util/IRFinder-BuildRefFromEnsembl
+++ b/bin/util/IRFinder-BuildRefFromEnsembl
@@ -109,7 +109,7 @@ if ($doDownload == 1) {
 	  $genome_file = "$basedir/OriginalRef/$fa";
 	  rename "$basedir/$randdir/$fa", $genome_file;
 
-	  system('wget',$base.'/gtf/'.$species.'/*.gtf.gz');
+	  system('wget',$base.'/gtf/'.$species.'/*[0-9][0-9].gtf.gz');
 	  my $gtf = getSingleFileFromDir("$basedir/$randdir");
 	  if (! $gtf) {
 		print "Failed to download gtf.gz file.\n";


### PR DESCRIPTION
… to be used due to generating "Failed to download gtf.gz" error.