### PR TITLE
IRFinder 1.2.0

### DIFF
--- a/bin/DESeq2Constructor.R
+++ b/bin/DESeq2Constructor.R
@@ -1,0 +1,57 @@
+gm_mean = function(x, na.rm=TRUE, zero.propagate = FALSE){
+  if(any(x < 0, na.rm = TRUE)){
+    return(NaN)
+  }
+  if(zero.propagate){
+    if(any(x == 0, na.rm = TRUE)){
+      return(0)
+    }
+    exp(mean(log(x), na.rm = na.rm))
+  } else {
+    exp(sum(log(x[x > 0]), na.rm=na.rm) / length(x))
+  }
+}
+
+DESeqDataSetFromIRFinder <- function(filePaths,designMatrix,designFormula){
+    res=c()
+    libsz=c()
+    irtest=read.table(filePaths[1])
+    if (irtest[1,1]=="Chr"){irtest=irtest[-1,]}
+    irnames=unname(apply(as.matrix(irtest),1,FUN=function(x){return(paste0(x[4],"/",x[1],":",x[2],"-",x[3],":",x[6]))}))
+    n=1
+    for (i in as.vector(files$V1)){
+        print(paste0("processing file ",n," at ",i))
+        irtab=read.table(i)
+        if (irtab[1,1]=="Chr"){irtab=irtab[-1,]}
+        #rn=unname(apply(irtab,1,FUN=function(x){return(paste0(x[4],"/",x[1],":",x[2],"-",x[3],":",x[6]))}))
+        #row.names(irtab)=rn
+        #tmp1=round(as.numeric(as.vector(irtab[irnames,9])))
+        #tmp2=as.numeric(as.vector(irtab[irnames,19]))
+        tmp1=as.numeric(as.vector(irtab[,9]))
+        tmp2=as.numeric(as.vector(irtab[,19]))
+        tmp3=tmp1+tmp2
+        res=cbind(res,tmp1)
+        libsz=cbind(libsz,tmp3)
+        n=n+1
+    }
+    res.rd=round(res)
+    libsz.rd=round(libsz)
+    colnames(res)=as.vector(designMatrix[,1])
+    rownames(res)=irnames
+    colnames(libsz)=as.vector(designMatrix[,1])
+    rownames(libsz)=irnames
+    colnames(libsz.rd)=as.vector(designMatrix[,1])
+    rownames(libsz.rd)=irnames
+    dd = DESeqDataSetFromMatrix(countData = res.rd, colData = designMatrix, design = designFormula)
+    colnames(dd)=as.vector(designMatrix[,1])
+    rownames(dd)=irnames
+    gm=apply(libsz.rd,1,gm_mean)
+    normFactors <- libsz / gm
+    normFactors[normFactors==0]=1
+    normalizationFactors(dd) <- normFactors
+    sp=libsz-res
+    final=list(dd,res,sp)
+    names(final)=c("DESeq2Object","IntronDepth","SpliceDepth")
+    return(final)
+}
+

--- a/bin/util/Build-BED-refs.sh
+++ b/bin/util/Build-BED-refs.sh
@@ -117,9 +117,10 @@ cat <(awk 'BEGIN {FS="\t"; OFS="\t"} {$4 = "dir/" $4; print}' < tmp-dir.IntronCo
 
 echo "Build Ref 11"
 
+#in Bedtools v2.26, chromosome-length file need to be sorted (sort -k1,1) according to chromosome names before being passed to complement function
 bedtools slop -b 10000 -g "$CHRLEN" -i tmp.all.annotations \
 | sort -t $'\t' -S 500M -k1,1 -k2,2n -k3,3n | bedtools merge -d 1000 -i stdin \
-| bedtools complement -i stdin -g "$CHRLEN" \
+| bedtools complement -i stdin -g <(sort -k1,1 "$CHRLEN") \
 | awk 'BEGIN {FS="\t"; OFS="\t"} (length($1)<=2) {$4 = "Intergenic/" $1; print $1, $2, $3, $4}' > intergenic.ROI.bed
 
 

--- a/bin/util/Mapability
+++ b/bin/util/Mapability
@@ -42,7 +42,8 @@ echo Commence Coverage calculation.
 
 CHRLEN="$STARGENOME/chrNameLength.txt"
 
-time ls "$TMPCHR"/*.bed."$TMPEXT" | xargs --max-args 1 --max-procs "$THREADS" -I{} bash -c "\"$TMPCMP\" -cd < {} | bedtools genomecov -i stdin -bga -g \"$CHRLEN\" | awk 'BEGIN {FS=\"\t\"; OFS=\"\t\"} (\$4 < 5) {print \$1, \$2, \$3}' | bedtools merge -i stdin > {}.exclusion"
+#add awk 'NR==1{chr=\$1;print}\$1==chr{print}' |
+time ls "$TMPCHR"/*.bed."$TMPEXT" | xargs --max-args 1 --max-procs "$THREADS" -I{} bash -c "\"$TMPCMP\" -cd < {} | bedtools genomecov -i stdin -bga -g \"$CHRLEN\"| awk 'NR==1{chr=\$1;print}\$1==chr{print}' | awk 'BEGIN {FS=\"\t\"; OFS=\"\t\"} (\$4 < 5) {print \$1, \$2, \$3}' | bedtools merge -i stdin > {}.exclusion"
 
 time cat "$TMPCHR"/*.exclusion | sort -S5G -k1,1 -k2,2n -k3,3n | gzip > MapabilityExclusion.bed.gz
 


### PR DESCRIPTION
**1.2.0:**
1. IRFinder is now compatible with GLM-based analysis. This is achieved by passing IRFinder result to DESeq2 using the function in bin/DESeq2Constructor.R. See Wiki page for details
2. Fixed the conflict with latest version "bedtools complement” that used to cause failure in preparing IRFinder reference
3. Improve memory usage when passing lines to bedtools genomecov. This is also supposed to benefit reference preparation of those genomes with a lot of chromosomes contigs. Thanks for the smart solution from Andreas @andpet0101.