### PR TITLE
Use env to find perl

### DIFF
--- a/bin/AdaptorDetect.pl
+++ b/bin/AdaptorDetect.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use List::Util qw(sum max min);
 use Data::Dumper;

--- a/bin/analysisWithLowReplicates.pl
+++ b/bin/analysisWithLowReplicates.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use Data::Dumper;
 use List::Util qw(max min);

--- a/bin/analysisWithNoReplicates.pl
+++ b/bin/analysisWithNoReplicates.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use Data::Dumper;
 use List::Util qw(max min);

--- a/bin/util/IRFinder-BuildRefFromEnsembl
+++ b/bin/util/IRFinder-BuildRefFromEnsembl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use Cwd;
 use File::Spec;

--- a/bin/util/IntronExclusion.pl
+++ b/bin/util/IntronExclusion.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 
 my %genes;

--- a/bin/util/bed-to-intron+exon.pl
+++ b/bin/util/bed-to-intron+exon.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 #0	1	2	3						4	5	6	7	8	9	10		11
 #1      11868   14409   ENST00000456328/processed_transcript/DDX11L1    0       +       11868   14409   0       3       359,109,1189,   0,744,1352,

--- a/bin/util/generateReadsError.pl
+++ b/bin/util/generateReadsError.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 #use Fcntl;
 

--- a/bin/util/gtf2bed-custom.pl
+++ b/bin/util/gtf2bed-custom.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (c) 2011 Erik Aronesty (erik@q32.com)
 # 

--- a/bin/util/warnings
+++ b/bin/util/warnings
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 
 my $outDir = $ARGV[0];


### PR DESCRIPTION
I ran into an issue with using IRFinder on a shared system because Perl is not located where the shebangs state it should be. An alternative is to use env to find perl, which alleviates the specific issue I had while also retaining usage by those with perl is the normal location previously used in the sehbangs.